### PR TITLE
Fix env file usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   hyperindex:
     build: ./infra/hyperindex
-    env_file: env.template
+    env_file: .env
     depends_on:
       postgres:
         condition: service_healthy
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.refresher
-    env_file: env.template
+    env_file: .env
     volumes:
       - .:/workdir
     depends_on:


### PR DESCRIPTION
## Summary
- load runtime env vars from `.env` instead of the template

## Testing
- `python3 scripts/validate_pipeline.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849a64a54488331a420cdbd12b230ed